### PR TITLE
Add resource instance path for reordering

### DIFF
--- a/lib/active_admin/reorderable/table_methods.rb
+++ b/lib/active_admin/reorderable/table_methods.rb
@@ -11,7 +11,7 @@ module ActiveAdmin
       private
 
       def reorder_handle_for(resource)
-        url = url_for([:reorder, active_admin_namespace.name, resource])
+        url = active_admin_resource_for(resource.class).route_reorder_instance_path resource
         span(reorder_handle_content, :class => 'reorder-handle', 'data-reorder-url' => url)
       end
 

--- a/lib/active_admin/resource/route.rb
+++ b/lib/active_admin/resource/route.rb
@@ -1,0 +1,20 @@
+module ActiveAdmin
+  class Resource
+    module Routes
+      def route_reorder_instance_path(resource, additional_params = {})
+        route_builder.reorder_instance_path(resource, additional_params)
+      end
+
+      private
+
+      class RouteBuilder
+        def reorder_instance_path(instance, additional_params = {})
+          path = resource.resources_configuration[:self][:route_instance_name]
+          route_name = route_name(path, action: :reorder)
+
+          routes.public_send route_name, *route_instance_params(instance), additional_params
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
By extending the routing module in a manner similar to how the :edit
action is done in ActiveAdmin, all routing options should work.